### PR TITLE
管理者：スタッフ別勤怠一覧画面の実装

### DIFF
--- a/src/app/Http/Controllers/StaffController.php
+++ b/src/app/Http/Controllers/StaffController.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Attendance;
+use App\Models\BreakTime;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
 
 class StaffController extends Controller
 {
@@ -13,8 +17,22 @@ class StaffController extends Controller
         return view('admin.staff-list', compact('staffMembers'));
     }
 
-    public function detail()
+    public function detail(Request $request, $id)
     {
-        return view('admin.staff-detail');
+        $user = User::findOrFail($id);
+
+        $month = $request->query('month', Carbon::now()->format('Y-m'));
+
+        $currentMonth = Carbon::createFromFormat('Y-m', $month);
+
+        $previousMonth = $currentMonth->copy()->subMonth()->format('Y-m');
+
+        $nextMonth = $currentMonth->copy()->addMonth()->format('Y-m');
+
+        $attendances = Attendance::getMonthAttendance($user->id, $currentMonth);
+
+        $breakTimes = BreakTime::getMonthBreak($user->id, $currentMonth);
+
+        return view('admin.staff-detail', compact('currentMonth', 'previousMonth', 'nextMonth', 'user', 'attendances', 'breakTimes' ));
     }
 }

--- a/src/app/Http/Controllers/StaffController.php
+++ b/src/app/Http/Controllers/StaffController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+
+class StaffController extends Controller
+{
+    public function index()
+    {
+        $staffMembers = User::where('role_id', 2)->get(['id', 'name', 'email']);
+
+        return view('admin.staff-list', compact('staffMembers'));
+    }
+
+    public function detail()
+    {
+        return view('admin.staff-detail');
+    }
+}

--- a/src/public/css/admin-staff-detail.css
+++ b/src/public/css/admin-staff-detail.css
@@ -1,0 +1,97 @@
+.attendance-list-section {
+    width: 100%;
+    max-width: 700px;
+    padding: 0 16px;
+    margin: 0 auto;
+}
+
+.attendance-list-section h1 {
+    padding: 0px 15px;
+    font-size: 1.875rem;
+    font-weight: bold;
+    margin-bottom: 40px;
+    border-left: solid 8px #000;
+}
+
+.attendance-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    background-color: #fff;
+    border-radius: 10px;
+    height: 60px;
+}
+
+.prev-btn,
+.next-btn {
+    font-size: 1rem;
+    color: #737373;
+    background: transparent;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.attendance-header .btn:hover {
+    background: #555;
+}
+
+.attendance-header .current-month {
+    font-size: 1.25rem;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.calendar-icon {
+    width: 25px;
+    height: 25px;
+    color: #737373;
+    font-style: normal;
+}
+
+.attendance-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: center;
+    font-size: 1rem;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.attendance-table thead {
+    color: #737373;
+    background: transparent;
+    border-bottom: solid 8px #f0eff2;
+}
+
+.attendance-table th {
+    padding: 1rem;
+    border-bottom: solid 4px #f0eff2;
+    background: #fff;
+}
+
+.attendance-table td {
+    padding: 1rem;
+    background: #fff;
+    border-bottom: solid 2px #f0eff2;
+    color: #737373;
+    font-weight: 700;
+}
+
+.details-link {
+    color: #000;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.details-link:hover {
+    text-decoration: underline;
+}

--- a/src/public/css/admin-staff-detail.css
+++ b/src/public/css/admin-staff-detail.css
@@ -95,3 +95,22 @@
 .details-link:hover {
     text-decoration: underline;
 }
+
+.csv-btn {
+    background-color: #000;
+    color: #fff;
+    font-size: 1.375rem;
+    padding: 10px 40px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 700;
+    border: none;
+    float: right;
+    margin-top: 80px;
+}
+
+.csv-btn:hover {
+    color: #fff;
+    background-color: #666;
+}

--- a/src/public/css/admin-staff-list.css
+++ b/src/public/css/admin-staff-list.css
@@ -1,0 +1,54 @@
+.staff-list-section {
+    width: 100%;
+    max-width: 700px;
+    padding: 0 16px;
+    margin: 0 auto;
+}
+
+.staff-list-section h1 {
+    padding: 0px 15px;
+    font-size: 1.875rem;
+    font-weight: bold;
+    margin-bottom: 40px;
+    border-left: solid 8px #000;
+}
+
+.staff-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: center;
+    font-size: 1rem;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.staff-table thead {
+    color: #737373;
+    background: transparent;
+    border-bottom: solid 8px #f0eff2;
+}
+
+.staff-table th {
+    padding: 1rem;
+    border-bottom: solid 4px #f0eff2;
+    background: #fff;
+}
+
+.staff-table td {
+    padding: 1rem;
+    background: #fff;
+    border-bottom: solid 2px #f0eff2;
+    color: #737373;
+    font-weight: 700;
+}
+
+.details-link {
+    color: #000;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.details-link:hover {
+    text-decoration: underline;
+}

--- a/src/resources/views/admin/staff-detail.blade.php
+++ b/src/resources/views/admin/staff-detail.blade.php
@@ -8,5 +8,46 @@
 
 @section('content')
     <main class="wrapper">
+        <section class="attendance-list-section">
+            <h1>{{ $user->name }}さんの勤怠</h1>
+            <div class="attendance-header">
+                <a href="{{ url('/admin/attendance/staff/' . $user->id . '?month=' . $previousMonth) }}" class="prev-btn">&larr; 前月</a>
+                <span class="current-month">
+                    <img src="{{ asset('images/calendar.svg') }}" class="calendar-icon" alt="calendar-icon">
+                    {{ $currentMonth->format('Y/n') }}
+                </span>
+                <a href="{{ url('/admin/attendance/staff/' . $user->id . '?month=' . $nextMonth) }}" class="next-btn">翌月 &rarr;</a>
+            </div>
+            <table class="attendance-table">
+                <thead>
+                    <tr>
+                        <th>日付</th>
+                        <th>出勤</th>
+                        <th>退勤</th>
+                        <th>休憩</th>
+                        <th>合計</th>
+                        <th>詳細</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($attendances as $attendance)
+                        <tr>
+                            <td>{{ \Carbon\Carbon::parse($attendance->date)->isoFormat('M/D') .
+                                '(' .
+                                ['日', '月', '火', '水', '木', '金', '土'][\Carbon\Carbon::parse($attendance->date)->dayOfWeek] .
+                                ')' }}</td>
+                            <td>{{ $attendance->start_time }}</td>
+                            <td>{{ $attendance->end_time }}</td>
+                            <td>{{ optional($breakTimes->firstWhere('attendance_id', $attendance->id))->formatted_break_time ?? '-' }}
+                            </td>
+                            <td>{{ $attendance->working_hours }}
+                            </td>
+                            <td><a href="{{ route('attendance.detail', ['attendance_id' => $attendance->id]) }}"
+                                    class="details-link">詳細</a></td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </section>
     </main>
 @endsection

--- a/src/resources/views/admin/staff-detail.blade.php
+++ b/src/resources/views/admin/staff-detail.blade.php
@@ -48,6 +48,7 @@
                     @endforeach
                 </tbody>
             </table>
+            <button class="csv-btn" type="submit">CSV出力</button>
         </section>
     </main>
 @endsection

--- a/src/resources/views/admin/staff-detail.blade.php
+++ b/src/resources/views/admin/staff-detail.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('title', 'スタッフ別勤怠一覧')
+
+@push('css')
+    <link rel="stylesheet" href="{{ asset('css/admin-staff-detail.css') }}">
+@endpush
+
+@section('content')
+    <main class="wrapper">
+    </main>
+@endsection

--- a/src/resources/views/admin/staff-detail.blade.php
+++ b/src/resources/views/admin/staff-detail.blade.php
@@ -11,12 +11,12 @@
         <section class="attendance-list-section">
             <h1>{{ $user->name }}さんの勤怠</h1>
             <div class="attendance-header">
-                <a href="{{ url('/admin/attendance/staff/' . $user->id . '?month=' . $previousMonth) }}" class="prev-btn">&larr; 前月</a>
+                <a href="{{ route('admin.staff.detail', ['id' => $user->id, 'month' => $previousMonth]) }}" class="prev-btn">&larr; 前月</a>
                 <span class="current-month">
                     <img src="{{ asset('images/calendar.svg') }}" class="calendar-icon" alt="calendar-icon">
                     {{ $currentMonth->format('Y/n') }}
                 </span>
-                <a href="{{ url('/admin/attendance/staff/' . $user->id . '?month=' . $nextMonth) }}" class="next-btn">翌月 &rarr;</a>
+                <a href="{{ route('admin.staff.detail', ['id' => $user->id, 'month' => $nextMonth]) }}" class="next-btn">&rarr; 翌月</a>
             </div>
             <table class="attendance-table">
                 <thead>

--- a/src/resources/views/admin/staff-list.blade.php
+++ b/src/resources/views/admin/staff-list.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('title', 'スタッフ一覧')
+
+@push('css')
+    <link rel="stylesheet" href="{{ asset('css/admin-staff-list.css') }}">
+@endpush
+
+@section('content')
+    <main class="wrapper">
+        <section class="staff-list-section">
+            <h1>スタッフ一覧</h1>
+            <table class="staff-table">
+                <thead>
+                    <tr>
+                        <th>名前</th>
+                        <th>メールアドレス</th>
+                        <th>月次勤怠</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($staffMembers as $staffMember)
+                        <tr>
+                            <td> {{ $staffMember->name }} </td>
+                            <td> {{ $staffMember->email }} </td>
+                            <td><a href="{{ route('admin.staff.detail', ['id' => $staffMember->id]) }}" class="details-link">詳細</a></td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </section>
+    </main>
+@endsection

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -47,7 +47,7 @@
                                 <!-- 管理者でログインしている場合 -->
                                 <li class="header-nav-item"><a href="{{ route('admin.attendance.index') }}"
                                         class="header-nav-link">勤怠一覧</a></li>
-                                <li class="header-nav-item"><a href="" class="header-nav-link">スタッフ一覧</a></li>
+                                <li class="header-nav-item"><a href="{{ route('admin.staff.index') }}" class="header-nav-link">スタッフ一覧</a></li>
                                 <li class="header-nav-item"><a href="{{ route ('attendance.correct_index') }}" class="header-nav-link">申請一覧</a></li>
                                 <li class="header-nav-item">
                                     <form class="header-nav-logout" action="{{ route('admin.auth.destroy') }}"

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\AttendanceCorrectionController;
 use App\Http\Controllers\Auth\AuthenticationController;
 use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\StaffController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -37,6 +38,8 @@ Route::prefix('admin')->middleware('check.role:admin')->group(function () {
     Route::post('/login', [AuthenticationController::class, 'storeAdmin'])->name('admin.auth.store');
     Route::post('/logout', [AuthenticationController::class, 'destroyAdmin'])->name('admin.auth.destroy');
     Route::get('/attendance/list', [AdminAttendanceController::class, 'index'])->name('admin.attendance.index');
+    Route::get('/staff/list', [StaffController::class, 'index'])->name('admin.staff.index');
+    Route::get('/attendance/staff/{id}', [StaffController::class, 'detail'])->name('admin.staff.detail');
 });
 
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
スタッフ別勤怠一覧画面の実装をしました。

LMSスプリント5以下の項目です。

- スタッフ別勤怠一覧画面（管理者）のルーティング設定
- スタッフ別勤怠一覧画面（管理者）のコントローラー作成
- スタッフ別勤怠一覧画面（管理者）のアクションを定義
- スタッフ別勤怠一覧画面（管理者）の view を作成
- スタッフ別勤怠一覧画面（管理者）の勤怠一覧情報取得機能の実装
- スタッフ別勤怠一覧画面（管理者）の月表示変更機能の実装
- スタッフ別勤怠一覧画面（管理者）の詳細遷移機能の実装
- スタッフ別勤怠一覧画面（管理者）のスタイル作成
- スタッフ別勤怠一覧画面（管理者）のレスポンシブ対応