### PR TITLE
管理者：勤怠の修正リクエストの承認による勤怠の修正と直接勤怠を修正する処理を修正

### DIFF
--- a/src/app/Models/Attendance.php
+++ b/src/app/Models/Attendance.php
@@ -112,6 +112,7 @@ class Attendance extends Model
         return self::where('user_id', $userId)
             ->whereMonth('date', $currentMonth->month)
             ->whereYear('date', $currentMonth->year)
+            ->orderBy('date', 'asc')
             ->get()
             ->map(function ($attendance) {
                 if (is_null($attendance->start_time)) {
@@ -228,8 +229,15 @@ class Attendance extends Model
 
     public function updateAttendance(array $validatedData)
     {
+        // attendance_id から Attendance レコードを取得
+        $attendance = self::findOrFail($validatedData['attendance_id']);
+        $userId = $attendance->user_id;
+
         $formattedDate = Carbon::createFromFormat('Y年m月d日', "{$validatedData['date_year']}{$validatedData['date_day']}")
             ->format('Y-m-d');
+
+        // 対象レコードの削除
+        self::where('user_id', $userId)->where('date', $formattedDate)->delete(); // user_id と date が一致するレコード
 
         // end_time が入力されていない場合
         if (empty($validatedData['end_time'])) {
@@ -319,13 +327,13 @@ class Attendance extends Model
         $correctionId = $latestCorrection->id ?? null; // 修正IDを取得
 
         $dateYear = null;
-        if ($attendance->date) {
-            $dateYear = Carbon::parse($attendance->date)->format('Y年');
+        if ($latestCorrection->date) {
+            $dateYear = Carbon::parse($latestCorrection->date)->format('Y年');
         }
 
         $dateDay = null;
-        if ($attendance->date) {
-            $dateDay = Carbon::parse($attendance->date)->format('m月d日');
+        if ($latestCorrection->date) {
+            $dateDay = Carbon::parse($latestCorrection->date)->format('m月d日');
         }
 
         $startTime = null;

--- a/src/app/Models/AttendanceCorrection.php
+++ b/src/app/Models/AttendanceCorrection.php
@@ -109,7 +109,7 @@ class AttendanceCorrection extends Model
                 'correction_id' => $correction->id,
                 'correction_status_id' => $statusLabel,
                 'name' => $correction->attendance->user->name,
-                'date' => Carbon::parse($correction->attendance->date)->format('n月j日'),
+                'date' => Carbon::parse($correction->date)->format('n月j日'),
                 'reason' => $correction->reason,
                 'request_date' => Carbon::parse($correction->request_date)->format('n月j日'),
             ];

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -29,10 +29,12 @@ Route::group([], function () {
     Route::post('/login', [AuthenticationController::class, 'store'])->name('authentication.store');
     Route::post('/logout', [AuthenticationController::class, 'destroy'])->name('authentication.destroy');
 
+    // メール認証
     Route::get('/email/verify', function () {
         return view('auth.verify-email');
     })->name('verification.notice');
 
+    // ユーザーがメール認証を行うためのルート
     Route::get('/email/verify/{id}/{hash}', function (Request $request) {
         $user = User::findOrFail($request->route('id'));
 
@@ -46,17 +48,16 @@ Route::group([], function () {
     })->middleware(['signed'])->name('verification.verify');
 });
 
+Route::middleware(['check.role:user'])->group(function () {
+    Route::get('/attendance', [AttendanceController::class, 'show'])->name('attendance.show');
+    Route::post('/attendance', [AttendanceController::class, 'store'])->name('attendance.store');
+    Route::get('/attendance/list', [AttendanceController::class, 'index'])->name('attendance.index');
+});
+
 Route::prefix('admin')->middleware('check.role:admin')->group(function () {
     Route::get('/login', [AuthenticationController::class, 'showAdmin'])->name('admin.auth.show');
     Route::post('/login', [AuthenticationController::class, 'storeAdmin'])->name('admin.auth.store');
     Route::post('/logout', [AuthenticationController::class, 'destroyAdmin'])->name('admin.auth.destroy');
-});
-
-// 認証必要ルート
-Route::middleware(['auth', 'check.role:user'])->group(function () {
-    Route::get('/attendance', [AttendanceController::class, 'show'])->name('attendance.show');
-    Route::post('/attendance', [AttendanceController::class, 'store'])->name('attendance.store');
-    Route::get('/attendance/list', [AttendanceController::class, 'index'])->name('attendance.index');
 });
 
 Route::prefix('admin')->middleware(['auth', 'check.role:admin'])->group(function () {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -20,24 +20,46 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
+// 公開ルート
+Route::group([], function () {
+    Route::get('/register', [RegisterController::class, 'show'])->name('register.show');
+    Route::post('/register', [RegisterController::class, 'store'])->name('register.store');
 
-Route::get('/register', [RegisterController::class, 'show'])->name('register.show');
-Route::post('/register', [RegisterController::class, 'store'])->name('register.store');
+    Route::get('/login', [AuthenticationController::class, 'show'])->name('authentication.show');
+    Route::post('/login', [AuthenticationController::class, 'store'])->name('authentication.store');
+    Route::post('/logout', [AuthenticationController::class, 'destroy'])->name('authentication.destroy');
 
-Route::get('/login', [AuthenticationController::class, 'show'])->name('authentication.show');
-Route::post('/login', [AuthenticationController::class, 'store'])->name('authentication.store');
-Route::post('/logout', [AuthenticationController::class, 'destroy'])->name('authentication.destroy');
+    Route::get('/email/verify', function () {
+        return view('auth.verify-email');
+    })->name('verification.notice');
 
-Route::middleware(['check.role:user'])->group(function () {
-    Route::get('/attendance', [AttendanceController::class, 'show'])->name('attendance.show');
-    Route::post('/attendance', [AttendanceController::class, 'store'])->name('attendance.store');
-    Route::get('/attendance/list', [AttendanceController::class, 'index'])->name('attendance.index');
+    Route::get('/email/verify/{id}/{hash}', function (Request $request) {
+        $user = User::findOrFail($request->route('id'));
+
+        if (! hash_equals((string) $request->route('hash'), sha1($user->email))) {
+            throw new \Illuminate\Validation\ValidationException('Invalid email verification link.');
+        }
+
+        $user->markEmailAsVerified();
+
+        return redirect()->route('authentication.show')->with('verified', true);
+    })->middleware(['signed'])->name('verification.verify');
 });
 
 Route::prefix('admin')->middleware('check.role:admin')->group(function () {
     Route::get('/login', [AuthenticationController::class, 'showAdmin'])->name('admin.auth.show');
     Route::post('/login', [AuthenticationController::class, 'storeAdmin'])->name('admin.auth.store');
     Route::post('/logout', [AuthenticationController::class, 'destroyAdmin'])->name('admin.auth.destroy');
+});
+
+// 認証必要ルート
+Route::middleware(['auth', 'check.role:user'])->group(function () {
+    Route::get('/attendance', [AttendanceController::class, 'show'])->name('attendance.show');
+    Route::post('/attendance', [AttendanceController::class, 'store'])->name('attendance.store');
+    Route::get('/attendance/list', [AttendanceController::class, 'index'])->name('attendance.index');
+});
+
+Route::prefix('admin')->middleware(['auth', 'check.role:admin'])->group(function () {
     Route::get('/attendance/list', [AdminAttendanceController::class, 'index'])->name('admin.attendance.index');
     Route::get('/staff/list', [StaffController::class, 'index'])->name('admin.staff.index');
     Route::get('/attendance/staff/{id}', [StaffController::class, 'detail'])->name('admin.staff.detail');
@@ -51,25 +73,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/stamp_correction_request/list', [AttendanceCorrectionController::class, 'correct_index'])->name('attendance.correct_index');
 });
 
-Route::middleware('check.role:admin')->group(function () {
+Route::middleware(['auth', 'check.role:admin'])->group(function () {
     Route::get('/stamp_correction_request/approve/{id}', [AttendanceCorrectionController::class, 'show'])->name('correction.show');
     Route::post('/stamp_correction_request/approve', [AttendanceCorrectionController::class, 'approve'])->name('correction.approve');
 });
-
-// メール認証
-Route::get('/email/verify', function () {
-    return view('auth.verify-email');
-})->name('verification.notice');
-
-// ユーザーがメール認証を行うためのルート
-Route::get('/email/verify/{id}/{hash}', function (Request $request) {
-    $user = User::findOrFail($request->route('id'));
-
-    if (! hash_equals((string) $request->route('hash'), sha1($user->email))) {
-        throw new \Illuminate\Validation\ValidationException('Invalid email verification link.');
-    }
-
-    $user->markEmailAsVerified();
-
-    return redirect()->route('authentication.show')->with('verified', true);
-})->middleware(['signed'])->name('verification.verify');


### PR DESCRIPTION
以下を修正しました。

1. 日付の修正（例：1/1を1/20に変更）をしたときに日付が変更されない問題を修正
2. 1に伴い、勤怠の一覧がID順で表示していたため、日付順で表示されない場合があり、日付順に修正